### PR TITLE
Current implementation of 'find' has a bug that causes it to infinite loop

### DIFF
--- a/pystring.cpp
+++ b/pystring.cpp
@@ -974,8 +974,10 @@ typedef int Py_ssize_t;
         std::string s( str );
 
         std::string::size_type oldlen = oldstr.size(), newlen = newstr.size();
+        
+        cursor = find( s, oldstr, cursor );
 
-        while ( ( cursor = find( s, oldstr, cursor ) ) != -1 )
+        while ( cursor != -1 && cursor <= (int)s.size() )
         {
             if ( count > -1 && sofar >= count )
             {
@@ -983,8 +985,17 @@ typedef int Py_ssize_t;
             }
 
             s.replace( cursor, oldlen, newstr );
-
             cursor += (int) newlen;
+
+            if ( oldlen != 0)
+            {
+                cursor = find( s, oldstr, cursor );
+            }
+            else
+            {
+                ++cursor;
+            }
+
             ++sofar;
         }
 

--- a/test.cpp
+++ b/test.cpp
@@ -95,6 +95,17 @@ PYSTRING_ADD_TEST(pystring, rfind)
     PYSTRING_CHECK_EQUAL(pystring::rfind("abcabcabc", "abc", 6, 8), -1);
 }
 
+PYSTRING_ADD_TEST(pystring, replace)
+{
+    PYSTRING_CHECK_EQUAL(pystring::replace("abcdef", "foo", "bar"), "abcdef");
+    PYSTRING_CHECK_EQUAL(pystring::replace("abcdef", "ab", "cd"),   "cdcdef");
+    PYSTRING_CHECK_EQUAL(pystring::replace("abcdef", "ab", ""),     "cdef");
+    PYSTRING_CHECK_EQUAL(pystring::replace("abcabc", "ab",  ""),    "cc");
+    PYSTRING_CHECK_EQUAL(pystring::replace("abcdef",   "",  ""),    "abcdef");
+    PYSTRING_CHECK_EQUAL(pystring::replace("abcdef",   "", "."),    ".a.b.c.d.e.f.");
+}
+
+
 PYSTRING_ADD_TEST(pystring, slice)
 {
     PYSTRING_CHECK_EQUAL(pystring::slice(""), "");
@@ -300,4 +311,5 @@ PYSTRING_ADD_TEST(pystring_os_path, splitext)
     splitext_nt(root, ext, "c:\\a.b.c"); PYSTRING_CHECK_EQUAL(root, "c:\\a.b"); PYSTRING_CHECK_EQUAL(ext, ".c");
     splitext_nt(root, ext, "c:\\a_b.c"); PYSTRING_CHECK_EQUAL(root, "c:\\a_b"); PYSTRING_CHECK_EQUAL(ext, ".c");
 }
+
 


### PR DESCRIPTION
I fixed the bug so that behavior matches python's implementation of find with an empty string as the source string, and added a small suite of unit tests for the find function (which includes cases for the fixed bugs).

I tried to keep the code style consistent with what's there already, but feel free to alter it in any way you see fit :)
