### PR TITLE
Allow default values in Makefile to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-LIBTOOL = libtool
-LIBDIR = /usr/lib
-CXX = g++
-CXXFLAGS = -g -O3 -Wall -Wextra -Wshadow -Wconversion -Wcast-qual -Wformat=2
+LIBTOOL ?= libtool
+LIBDIR ?= /usr/lib
+CXX ?= g++
+CXXFLAGS ?= -g -O3 -Wall -Wextra -Wshadow -Wconversion -Wcast-qual -Wformat=2
 
 all: libpystring.la
 


### PR DESCRIPTION
This is handy when building this within an automated build system where creating and applying a patch is a PITA.
