### PR TITLE
testing both posix and nt version of the abspath call

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -513,10 +513,13 @@ PYSTRING_ADD_TEST(pystring, translate)
 
 PYSTRING_ADD_TEST(pystring, abspath)
 {
-    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath("", "/net"), "/net");
-    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath("../jeremys", "/net/soft_scratch/users/stevel"), "/net/soft_scratch/users/jeremys");
-    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath("../../../../tmp/a", "/net/soft_scratch/users/stevel"), "/tmp/a");
+    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath_posix("", "/net"), "/net");
+    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath_posix("../jeremys", "/net/soft_scratch/users/stevel"), "/net/soft_scratch/users/jeremys");
+    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath_posix("../../../../tmp/a", "/net/soft_scratch/users/stevel"), "/tmp/a");
  
+    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath_nt("", "c:\\net"), "c:\\net");
+    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath_nt("..\\jeremys", "c:\\net\\soft_scratch\\users\\stevel"), "c:\\net\\soft_scratch\\users\\jeremys");
+    PYSTRING_CHECK_EQUAL(pystring::os::path::abspath_nt("..\\..\\..\\..\\tmp\\a", "c:\\net\\soft_scratch\\users\\stevel"), "c:\\tmp\\a"); 
 }
 
 PYSTRING_ADD_TEST(pystring_os_path, splitdrive)


### PR DESCRIPTION
Looks like the way the code is structured, there is a top level abspath call which would call a lower level abspath_posix and abspath_nt depending on which os you built the library on.

As far as testing, all the other tests call the $func_nt and $func_posix directly with appropriate test data which works on both windows/linux system (though arguably you may be testing more than you need to test).

For some reason, abspath was the only one testing the top level abspath call.
So I just changed to test both nt and posix like the others + appropriate test inputs for the windows version.