### PR TITLE
Add CMake build option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,31 @@
 project(pystring
-	LANGUAGES CXX
-	)
+    LANGUAGES CXX
+    )
 
 cmake_minimum_required(VERSION 3.0)
 
 set(CMAKE_CXX_FLAGS "-O3 -Wall -Wextra -Wshadow -Wconversion -Wcast-qual -Wformat=2 ${CMAKE_CXX_FLAGS}")
 
 include(GNUInstallDirs)
-mark_as_advanced(CLEAR CMAKE_INSTALL_LIBDIR)
+mark_as_advanced(CLEAR CMAKE_INSTALL_LIBDIR
+                       CMAKE_INSTALL_INCLUDEDIR
+                       )
 
 add_library(pystring SHARED
     pystring.cpp
-	)
+    )
 
 set_target_properties(pystring PROPERTIES 
     SOVERSION 0.0
-	)
+    )
 
 install(TARGETS pystring
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	)
+    )
+
+install(FILES pystring.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pystring
+    )
 
 add_executable(test pystring.cpp test.cpp)
 target_compile_definitions(test PRIVATE PYSTRING_UNITTEST=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(pystring
+	LANGUAGES CXX
+	)
+
+cmake_minimum_required(VERSION 3.0)
+
+set(CMAKE_CXX_FLAGS "-O3 -Wall -Wextra -Wshadow -Wconversion -Wcast-qual -Wformat=2 ${CMAKE_CXX_FLAGS}")
+
+include(GNUInstallDirs)
+mark_as_advanced(CLEAR CMAKE_INSTALL_LIBDIR)
+
+add_library(pystring SHARED
+    pystring.cpp
+	)
+
+set_target_properties(pystring PROPERTIES 
+    SOVERSION 0.0
+	)
+
+install(TARGETS pystring
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	)
+
+add_executable(test pystring.cpp test.cpp)
+target_compile_definitions(test PRIVATE PYSTRING_UNITTEST=1)


### PR DESCRIPTION
I need to package this for Fedora Linux in preparation of OpenColorIO 2.0 release. The simple Makefile is not very packager friendly. This should work for any Linux distro and can be updated for MacOS and Windows if needed.