### PR TITLE
Add a meson build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,12 @@
+project('pystring', 'cpp', default_options : ['cpp_std=c++11'])
+
+libpystring = library('pystring', 'pystring.cpp', install: true)
+install_headers('pystring.h')
+
+pkg = import('pkgconfig')
+pkg.generate(libpystring,
+    filebase : 'pystring',
+    name : 'pystring',
+    description : 'C++ string library with a python-like interface',
+    url : 'github.com/imageworks/pystring',
+)


### PR DESCRIPTION
Add a simple but effective Meson build file. Installs correctly the library and header file and add a pkg-config file.