### PR TITLE
Proper installation paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 LIBTOOL ?= libtool
-LIBDIR ?= /usr/lib
+PREFIX ?= /usr
+INCLUDEDIR ?= ${PREFIX}/include/pystring
+LIBDIR ?= ${PREFIX}/lib
 CXX ?= g++
 CXXFLAGS ?= -g -O3 -Wall -Wextra -Wshadow -Wconversion -Wcast-qual -Wformat=2
 
@@ -12,7 +14,8 @@ libpystring.la: pystring.lo
 	$(LIBTOOL) --mode=link --tag=CXX $(CXX) -o $@ $< -rpath $(LIBDIR)
 
 install: libpystring.la
-	$(LIBTOOL) --mode=install install -c $< $(LIBDIR)/$<
+	$(LIBTOOL) --mode=install install -Dm755 $< $(DESTDIR)$(LIBDIR)/$<
+	$(LIBTOOL) --mode=install install -Dm644 pystring.h $(DESTDIR)$(INCLUDEDIR)/pystring.h
 
 clean:
 	$(RM) -fr pystring.lo pystring.o libpystring.la .libs


### PR DESCRIPTION
It's Makefile convention to be able to install to `DESTDIR`. This is especially important for packaging on Linux distributions but might be convenient for other users as well. Also this introduces `PREFIX`, another convention.