### PR TITLE
Simplify github actions CI yaml file to use stock github runners and latest versions of windows/mac/ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-# borrowed this from:
-# https://raw.githubusercontent.com/AcademySoftwareFoundation/Imath/main/.github/workflows/ci_workflow.yml
-# with some slight simplification
+# simple ci config the idea is to use the latest ubuntu, macos, and windows that github runners give us
+# test a few different compilers (gcc/clang) in debug and release
+# and run our tests via ctest
 
 name: CI
 
@@ -14,219 +14,69 @@ on:
       - '**.md'
 
 jobs:
-  # Linux jobs run in Docker containers, so the latest OS version is OK. macOS 
-  # and Windows jobs need to be locked to specific virtual environment 
-  # versions to mitigate issues from OS updates, and will require maintenance 
-  # as OS versions are retired.
-  #
-  # GH Actions (Free plan) supports 20 concurrent jobs, with 5 concurrent macOS 
-  # jobs. This workflow tries to utilize (but not exceed) that budget to 
-  # promote timely CI.
-
-  # ---------------------------------------------------------------------------
-  # Linux
-  # ---------------------------------------------------------------------------
-  # TODO: Add ARM build. Add sanitize build.
 
   linux:
-    name: 'Linux CentOS 7 VFX CY${{ matrix.vfx-cy }} 
-      <${{ matrix.compiler-desc }} ,
-       config=${{ matrix.build-type }}, 
-       shared=${{ matrix.build-shared }}, 
-       cxx=${{ matrix.cxx-standard }}>'
-    # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
+    name: '${{ matrix.os }} / ${{ matrix.build-type }} / ${{ matrix.compiler-desc }} '  
+
     runs-on: ubuntu-latest
-    container:
-      # DockerHub: https://hub.docker.com/u/aswf
-      # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-openexr:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 9, 10, 11, 12, 13, 14, 15, 20, 21, 22]
+        build: [1, 2, 3, 4]
         include:
           # -------------------------------------------------------------------
-          # GCC, VFX CY2022
+          # CLANG, Release
           # -------------------------------------------------------------------
-          # C++17, Python 3.9
           - build: 1
             build-type: Release
             build-shared: 'ON'
             cxx-standard: 17
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc9.3.1
-            vfx-cy: 2022
+            cc_compiler: clang
+            cxx_compiler: clang++
+            compiler-desc: clang
+            os: ubuntu-latest
 
-          # C++17, Python 3.9.7, Debug
+          # -------------------------------------------------------------------
+          # CLANG, Debug
+          # -------------------------------------------------------------------
           - build: 2
             build-type: Debug
             build-shared: 'ON'
             cxx-standard: 17
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc9.3.1
-            vfx-cy: 2022
+            cc_compiler: clang
+            cxx_compiler: clang++
+            compiler-desc: clang
+            os: ubuntu-latest
 
-          # C++17, Python 3.9.7, Static
+          # -------------------------------------------------------------------
+          # gcc, Release
+          # -------------------------------------------------------------------
           - build: 3
             build-type: Release
-            build-shared: 'OFF'
+            build-shared: 'ON'
             cxx-standard: 17
             cxx-compiler: g++
             cc-compiler: gcc
-            compiler-desc: gcc9.3.1
-            vfx-cy: 2022
+            compiler-desc: gcc
+            os: ubuntu-latest
 
-          # C++14, Python 3.9.7, Static
+          # -------------------------------------------------------------------
+          # gcc, Debug
+          # -------------------------------------------------------------------
           - build: 4
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 14
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc9.3.1
-            vfx-cy: 2022
-
-          # C++17, no Python
-            # - build: 5
-            # build-type: Release
-            # build-shared: 'ON'
-            # cxx-standard: 17
-            # cxx-compiler: g++
-            # cc-compiler: gcc
-            # compiler-desc: gcc9.3.1
-            # python: 'OFF'
-            # python-desc: no python
-            # vfx-cy: 2022
-
-          # -------------------------------------------------------------------
-          # GCC, VFX CY2021
-          # -------------------------------------------------------------------
-          # C++17, Python 3.7.9
-          - build: 9
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 17
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc9.3.1
-            python: 'ON'
-            vfx-cy: 2021
-
-          # -------------------------------------------------------------------
-          # GCC, VFX CY2020
-          # -------------------------------------------------------------------
-          # C++14, Python 3.7
-          - build: 10
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 14
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc6.3.1
-            vfx-cy: 2020
-
-          # -------------------------------------------------------------------
-          # GCC, VFX CY2019
-          # -------------------------------------------------------------------
-          # C++11, Python 2.7
-          - build: 11
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 11
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc6.3.1
-            vfx-cy: 2019
-
-          # -------------------------------------------------------------------
-          # Clang, VFX CY2022
-          # -------------------------------------------------------------------
-          # C++17, Python 3.9
-          - build: 12
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10.4
-            vfx-cy: 2022
-
-          # C++17, Python 3.9.7, Debug
-          - build: 13
             build-type: Debug
             build-shared: 'ON'
             cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10.4
-            vfx-cy: 2022
-
-          # C++17, Python 3.9.7, Static
-          - build: 14
-            build-type: Release
-            build-shared: 'OFF'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10.4
-            vfx-cy: 2022
-
-          # C++14, Python 3.9.7, Static
-          - build: 15
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 14
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10.4
-            vfx-cy: 2022
-
-          # -------------------------------------------------------------------
-          # Clang, VFX CY2021
-          # -------------------------------------------------------------------
-          # C++17, Python 3.7.9
-          - build: 20
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10.4
-            vfx-cy: 2021
-
-          # -------------------------------------------------------------------
-          # Clang, VFX CY2020
-          # -------------------------------------------------------------------
-          # C++14, Python 3.7
-          - build: 21
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 14
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang7.8
-            vfx-cy: 2020
-
-          # -------------------------------------------------------------------
-          # Clang, VFX CY2019
-          # -------------------------------------------------------------------
-          # C++11, Python 2.7
-          - build: 22
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 11
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang7.8
-            vfx-cy: 2019
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: gcc
+            os: ubuntu-latest
 
     env:
       CXX: ${{ matrix.cxx-compiler }}
       CC: ${{ matrix.cc-compiler }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create build directories
         run: |
           mkdir _install
@@ -249,32 +99,27 @@ jobs:
         working-directory: _build
       - name: Test
         run: |
-          ctest -C ${{ matrix.build_type }}
+          ctest --build-config ${{ matrix.build_type }} --verbose
         working-directory: _build
 
   # ---------------------------------------------------------------------------
   # macOS
   # ---------------------------------------------------------------------------
   
-  macos_no_python:
-    name: 'macOS 10.15 
-      <AppleClang 11.0 
-       config=${{ matrix.build-type }}, 
-       shared=${{ matrix.build-shared }}, 
-       cxx=${{ matrix.cxx-standard }}, 
-       docs=${{ matrix.build-docs }}>'
-    runs-on: macos-10.15
+  macos:
+    name: '${{ matrix.os }} / ${{ matrix.build-type }}'  
+    runs-on: macos-latest
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5]
+        build: [1, 2]
         include:
-          # C++11
+
+          # Release
           - build: 1
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'ON'
             cxx-standard: 17
-            exclude-tests:
+            os: macos-latest
 
           # Debug
           - build: 2
@@ -282,34 +127,11 @@ jobs:
             build-shared: 'ON'
             build-docs: 'OFF'
             cxx-standard: 17
-            exclude-tests:
+            os: macos-latest
 
-          # Static
-          - build: 3
-            build-type: Debug
-            build-shared: 'OFF'
-            build-docs: 'OFF'
-            cxx-standard: 17
-            exclude-tests:
-
-          # C++14
-          - build: 4
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            cxx-standard: 14
-            exclude-tests:
-
-          # C++11
-          - build: 5
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            cxx-standard: 11
-            exclude-tests:
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create build directories
         run: |
           mkdir _install
@@ -330,11 +152,10 @@ jobs:
           cmake --build . \
                 --target install \
                 --config ${{ matrix.build-type }} \
-                -- -j2
         working-directory: _build
       - name: Test
         run: |
-          ctest -C ${{ matrix.build_type }}
+          ctest --build-config ${{ matrix.build_type }} --verbose
         working-directory: _build
 
   # ---------------------------------------------------------------------------
@@ -342,113 +163,31 @@ jobs:
   # ---------------------------------------------------------------------------
 
   windows:
-    name: 'Windows 2019 
-      <${{ matrix.compiler-desc }},
-       config=${{ matrix.build-type }}, 
-       shared=${{ matrix.build-shared }}, 
-       cxx=${{ matrix.cxx-standard }}, 
-       docs=${{ matrix.build-docs }}>'
-    runs-on: windows-${{ matrix.osver }}
+    name: '${{ matrix.os }} / ${{ matrix.build-type }}'
+    runs-on: windows-latest
     strategy:
       matrix:
-        build: [1, 3, 4, 6, 7, 8]
+        build: [1, 2]
         include:
-          # -------------------------------------------------------------------
-          # VFX CY2022 - C++17 - Windows 2019
-          # -------------------------------------------------------------------
-          # C++17, Release Shared
+
+          # Release          
           - build: 1
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'ON'
-            compiler-desc: msvc16.11
             cxx-standard: 17
-            vfx-cy: 2022
-            exclude-tests:
-            osver: 2019
+            os: windows-latest
 
-          # C++17, Debug -
-          ## - build: 2
-          ##   build-type: Debug
-          ##   build-shared: 'ON'
-          ##   build-docs: 'OFF'
-          ##   cxx-standard: 17
-          ##   exclude-tests:
-
-          # C++17, Release Static
-          - build: 3
-            build-type: Release
-            build-shared: 'OFF'
-            build-docs: 'OFF'
-            compiler-desc: msvc16.11
-            cxx-standard: 17
-            vfx-cy: 2022
-            exclude-tests:
-            osver: 2019
-
-          # -------------------------------------------------------------------
-          # VFX CY2022 - C++17 - Windows 2022
-          # -------------------------------------------------------------------
-          # C++17, Release Shared
-          - build: 4
-            build-type: Release
+          # Debug
+          - build: 2
+            build-type: Debug
             build-shared: 'ON'
-            build-docs: 'ON'
-            compiler-desc: msvc17.1
             cxx-standard: 17
-            vfx-cy: 2022
-            exclude-tests:
-            osver: 2022
+            os: windows-latest
 
-          # C++17, Debug -
-          ## - build: 5
-          ##   build-type: Debug
-          ##   build-shared: 'ON'
-          ##   build-docs: 'OFF'
-          ##   cxx-standard: 17
-          ##   exclude-tests:
-
-          # C++17, Release Static
-          - build: 6
-            build-type: Release
-            build-shared: 'OFF'
-            build-docs: 'OFF'
-            compiler-desc: msvc17.1
-            cxx-standard: 17
-            vfx-cy: 2022
-            exclude-tests:
-            osver: 2022
-
-          # -------------------------------------------------------------------
-          # VFX CY2020 - C++14 - Windows 2019
-          # -------------------------------------------------------------------
-          # C++14, Release Shared
-          - build: 7
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            compiler-desc: msvc16.11
-            cxx-standard: 14
-            vfx-cy: 2020
-            exclude-tests:
-            osver: 2019
-
-          # -------------------------------------------------------------------
-          # VFX CY2019 - C++11 - Windows 2019
-          # -------------------------------------------------------------------
-          # C++11, Release Shared
-          - build: 8
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            compiler-desc: msvc16.11
-            cxx-standard: 11
-            exclude-tests:
-            osver: 2019
-
+            
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create build directories
         run: |
           mkdir _install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       CC: ${{ matrix.cc-compiler }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create build directories
         run: |
           mkdir _install
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create build directories
         run: |
           mkdir _install
@@ -187,7 +187,7 @@ jobs:
             
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create build directories
         run: |
           mkdir _install


### PR DESCRIPTION
Attempt to simplify the pystring CI setup.
The idea here is to use the stock github runners, one for linux, one for mac and one for windows.
Whatever they give us as latest.
Which I hope would be enough for pystring.

If this doesn't prove successful we can try to maybe take an example from one of the ASWF projects that use the aswf docker images and see if we can simplify that.

